### PR TITLE
Add debug quad drawing support to scene system

### DIFF
--- a/src/Apps/Samples/States/DemoDebugDrawingState.cpp
+++ b/src/Apps/Samples/States/DemoDebugDrawingState.cpp
@@ -33,6 +33,7 @@ FsmAction DemoDebugDrawingState::update() {
 	sceneSystem.drawLine({2, 1, 0}, {2, -1, 0}, Color::yellow);
 	sceneSystem.drawLine({3, 1, 0}, {3, -1, 0}, Color::gray);
 	sceneSystem.drawLine({4, 1, 0}, {4, -1, 0}, Color::magenta);
+	sceneSystem.drawQuad({0, 2, 0}, {1, 1}, Color::cyan);
 
 	return FsmAction::none();
 }

--- a/src/Engine/Core/RenderSteps/DrawDebugRenderStep.cpp
+++ b/src/Engine/Core/RenderSteps/DrawDebugRenderStep.cpp
@@ -91,23 +91,27 @@ void DrawDebug::execute(RenderStepInfo& renderInfo) {
 
 	// Fill Vertex Info for Quads
 	{
-		auto view = _ecs.sceneRegistry().view<DebugQuad>();
-		for (auto&& [entity, quad] : view.each()) {
-			glm::vec3 p1 = quad.position + glm::vec3(-quad.size.x * 0.5f, -quad.size.y * 0.5f, 0);
-			glm::vec3 p2 = quad.position + glm::vec3(quad.size.x * 0.5f, -quad.size.y * 0.5f, 0);
-			glm::vec3 p3 = quad.position + glm::vec3(quad.size.x * 0.5f, quad.size.y * 0.5f, 0);
-			glm::vec3 p4 = quad.position + glm::vec3(-quad.size.x * 0.5f, quad.size.y * 0.5f, 0);
-			if (vertexCount + 8u >= _vertices.size()) {
-				break;
+		if (vertexCount + 8u < _vertices.size()) {
+			auto view = _ecs.sceneRegistry().view<DebugQuad>();
+			for (auto&& [entity, quad] : view.each()) {
+				glm::vec3 p1 = quad.position + glm::vec3(-quad.size.x * 0.5f, -quad.size.y * 0.5f, 0);
+				glm::vec3 p2 = quad.position + glm::vec3(quad.size.x * 0.5f, -quad.size.y * 0.5f, 0);
+				glm::vec3 p3 = quad.position + glm::vec3(quad.size.x * 0.5f, quad.size.y * 0.5f, 0);
+				glm::vec3 p4 = quad.position + glm::vec3(-quad.size.x * 0.5f, quad.size.y * 0.5f, 0);
+
+				_vertices[vertexCount++] = {p1, quad.color};
+				_vertices[vertexCount++] = {p2, quad.color};
+				_vertices[vertexCount++] = {p2, quad.color};
+				_vertices[vertexCount++] = {p3, quad.color};
+				_vertices[vertexCount++] = {p3, quad.color};
+				_vertices[vertexCount++] = {p4, quad.color};
+				_vertices[vertexCount++] = {p4, quad.color};
+				_vertices[vertexCount++] = {p1, quad.color};
+
+				if (vertexCount + 8u >= _vertices.size()) {
+					break;
+				}
 			}
-			_vertices[vertexCount++] = {p1, quad.color};
-			_vertices[vertexCount++] = {p2, quad.color};
-			_vertices[vertexCount++] = {p2, quad.color};
-			_vertices[vertexCount++] = {p3, quad.color};
-			_vertices[vertexCount++] = {p3, quad.color};
-			_vertices[vertexCount++] = {p4, quad.color};
-			_vertices[vertexCount++] = {p4, quad.color};
-			_vertices[vertexCount++] = {p1, quad.color};
 		}
 	}
 

--- a/src/Engine/Core/RenderSteps/DrawDebugRenderStep.cpp
+++ b/src/Engine/Core/RenderSteps/DrawDebugRenderStep.cpp
@@ -89,6 +89,28 @@ void DrawDebug::execute(RenderStepInfo& renderInfo) {
 		}
 	}
 
+	// Fill Vertex Info for Quads
+	{
+		auto view = _ecs.sceneRegistry().view<DebugQuad>();
+		for (auto&& [entity, quad] : view.each()) {
+			glm::vec3 p1 = quad.position + glm::vec3(-quad.size.x * 0.5f, -quad.size.y * 0.5f, 0);
+			glm::vec3 p2 = quad.position + glm::vec3(quad.size.x * 0.5f, -quad.size.y * 0.5f, 0);
+			glm::vec3 p3 = quad.position + glm::vec3(quad.size.x * 0.5f, quad.size.y * 0.5f, 0);
+			glm::vec3 p4 = quad.position + glm::vec3(-quad.size.x * 0.5f, quad.size.y * 0.5f, 0);
+			if (vertexCount + 8u >= _vertices.size()) {
+				break;
+			}
+			_vertices[vertexCount++] = {p1, quad.color};
+			_vertices[vertexCount++] = {p2, quad.color};
+			_vertices[vertexCount++] = {p2, quad.color};
+			_vertices[vertexCount++] = {p3, quad.color};
+			_vertices[vertexCount++] = {p3, quad.color};
+			_vertices[vertexCount++] = {p4, quad.color};
+			_vertices[vertexCount++] = {p4, quad.color};
+			_vertices[vertexCount++] = {p1, quad.color};
+		}
+	}
+
 	if (vertexCount == 0u) {
 		return;
 	}

--- a/src/Engine/Scene/SceneSystem.cpp
+++ b/src/Engine/Scene/SceneSystem.cpp
@@ -222,6 +222,13 @@ void SceneSystem::drawSphere(const glm::vec3& position, float radius, const glm:
 	entity.addComponent<DebugDrawingLifetime>(lifetime);
 }
 
+void SceneSystem::drawQuad(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color, float lifetime) {
+	using namespace component;
+	auto entity = Entity::create("DebugQuad"_id, &_ecs.sceneRegistry());
+	entity.addComponent<DebugQuad>(position, size, color);
+	entity.addComponent<DebugDrawingLifetime>(lifetime);
+}
+
 Entity SceneSystem::getEntityByName(const HashId& name) {
 	auto view = _ecs.sceneRegistry().view<component::Name>();
 	for (auto [entity, nameComp] : view.each()) {

--- a/src/Engine/Scene/SceneSystem.h
+++ b/src/Engine/Scene/SceneSystem.h
@@ -43,6 +43,7 @@ public:
 	void drawLine(const glm::vec3& start, const glm::vec3& end, const glm::vec4& color, float lifetime = 0.016f);
 	void drawBox(const glm::vec3& position, const glm::vec3& size, const glm::vec4& color, float lifetime = 0.016f);
 	void drawSphere(const glm::vec3& position, float radius, const glm::vec4& color, float lifetime = 0.016f);
+	void drawQuad(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color, float lifetime = 0.016f);
 
 	[[nodiscard]] Entity getEntityByName(const HashId& name);
 	[[nodiscard]] Entity getCurrentCamera();

--- a/src/Libs/Ecs/Component/DebugDrawingComponent.h
+++ b/src/Libs/Ecs/Component/DebugDrawingComponent.h
@@ -22,6 +22,12 @@ struct DebugSphere {
 	glm::vec4 color;
 };
 
+struct DebugQuad {
+	glm::vec3 position;
+	glm::vec2 size;
+	glm::vec4 color;
+};
+
 struct DebugDrawingLifetime {
 	float lifetime{};
 };


### PR DESCRIPTION
Introduces a DebugQuad component and implements drawQuad in SceneSystem, allowing quads to be drawn for debug visualization. Updates rendering logic to handle quads and demonstrates usage in DemoDebugDrawingState.